### PR TITLE
Add Ubuntu Installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ latexmk --version
 To install LaTeX, run the following
 
 ```
-sudo apt install texlive-full
+sudo apt install texlive-most
 ```
 
 Run NeoVim to install plugins:

--- a/README.md
+++ b/README.md
@@ -613,6 +613,294 @@ fish_vi_key_bindings
 
 You are now read use NeoVim in Alacritty, complete with Tmux and the Fish shell.
 I highly recommend swapping the CapsLock and Esc keys as detailed below for using Arch on a Macbook Pro.
+# Arch Linux Installation
+
+Open the terminal and run the following commands:
+
+```
+sudo pacman -S neovim
+```
+
+Check to confirm that Python is installed:
+
+```
+python3 --version
+```
+
+If Python is not installed, run:
+
+```
+sudo pacman -S python
+```
+
+To check the health of your NeoVim install, open NeoVim by running `nvim` in the terminal and enter the following command:
+
+```
+:checkhealth
+```
+
+If Python 3 reports an error, run following in the terminal (to exit NeoVim, write `:qa!`):
+
+```
+pip3 install --user pynvim
+```
+
+NeoVim comes with an extremely austere set of defaults, including no mouse support, making it difficult to use prior to configuration.
+In order to install plugins, extending the features included in NeoVim, run the following:
+
+```
+sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+```
+
+Install the FZF fuzzy finder, Ripgrep, and Pandoc with the following commands respectively:
+
+```
+sudo pacman -S fzf
+sudo pacman -S ripgrep
+sudo pacman -S pandoc
+sudo pacman -S pandoc-citeproc
+```
+
+## [Git](https://git-scm.com/)
+
+Check to see whether Git is already installed by entering the following:
+
+```
+git --version
+```
+
+If Git is not installed, run:
+
+```
+sudo pacman -S install git
+```
+
+If you don't have Yay, you can install it by running the following:
+
+```
+git clone https://aur.archlinux.org/yay.git
+cd yay
+makepkg -si
+```
+
+If you run into errors, you may be missing the following dependency, which you can add by running:
+
+```
+sudo pacman -S base-devel
+```
+
+Next, install LazyGit using Yay by running:
+
+```
+yay -S lazygit
+```
+
+### Installing the GitHub Cli
+
+Assuming that you are using GitHub to host your repositories, it is convenient to install the GitHub Cli which allows you to make changes to your repositories directly from the terminal inside NeoVim:
+```
+sudo pacman -S github-cli
+```
+You will then need to follow the [instructions](https://cli.github.com/manual/) in order to authenticate GitHub Cli by running:
+```
+gh auth login
+```
+Set NeoVim as your default editor by running:
+```
+gh config set editor nvim
+```
+
+For further information, see the section **GitHub Cli** in the [Cheat Sheet](https://github.com/benbrastmckie/.config/blob/master/CheatSheet.md) as well as the [GitHub Cli Repo](https://github.com/cli/cli).
+
+### Adding an SSH Key to GitHub
+
+If you have not already, you can also add an SSH key by amending and running the following:
+
+```
+ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
+```
+
+Hit `return` once, entering your GitHub passphrase in response to the prompt.
+Next run:
+
+```
+bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_rsa
+```
+
+If you do not have `xclip` you can install it by running:
+
+```
+sudo pacman -S xclip
+```
+
+After the install, run the following to copy the SSH key to your system clipboard:
+
+```
+xclip -sel clip < ~/.ssh/id_rsa.pub
+```
+
+In the top right corner of your GitHub page, click `Profile -> Settings -> SSH and GPG Keys` selecting `New SSH Key`.
+Name the key after the devise you are using, pasting the SSH key from the clipboard into the appropriate field.
+Saving the key completes the addition.
+
+## [Configuration](https://github.com/benbrastmckie/.config)
+
+In order to clone the configuration files into the appropriate folder on your computer, enter the following into the terminal, hitting return after each line:
+
+```
+cd ~/.config
+git clone https://github.com/benbrastmckie/.config.git
+mkdir -p ~/.vim/files/info
+sudo pip3 install neovim-remote
+sudo pacman -S yarn
+```
+
+If you have not already installed MacTex on your computer, you can run the following command in order to check to see if it is already installed:
+
+```
+latexmk --version
+```
+
+To install LaTeX, run the following
+
+```
+sudo pacman -S texlive-most
+```
+
+Run NeoVim to install plugins:
+
+```
+nvim
+```
+
+After the plugins finish installing, quite NeoVim with `:qa!`.
+
+## [Zathura](https://pwmt.org/projects/zathura/)
+
+Install the Zathura pdf viewer by running:
+
+```
+sudo pacman -S zathura
+```
+
+After reopening NeoVim, enter the following command:
+
+```
+:checkhealth
+```
+
+Ignore any warnings for Python 2, Ruby, and Node.js.
+If other warnings are present, it is worth following the instructions provided by CheckHealth, or else troubleshooting the errors by Googling the associated messages as needed.
+
+
+## [Zotero](https://www.zotero.org/)
+
+Download and extract the [Zotero](https://www.zotero.org/download/) tarball in ~/Downloads, and move the extracted contents and set the launcher by running the following in the terminal:
+
+```
+sudo mv ~/Downloads/Zotero_linux-x86_64 /opt/zotero
+cd /opt/zotero
+sudo ./set_launcher_icon
+sudo ln -s /opt/zotero/zotero.desktop ~/.local/share/applications/zotero.desktop
+```
+
+Install Better-BibTex by downloading the latest release [here](https://retorque.re/zotero-better-bibtex/installation/) (click on the .xpi).
+Go into `Tools -> add-ons` and click the gear in the upper right-hand corner, selecting `Install Add-on From File` and navigate to the .xpi file in ~/Downloads.
+Go into `Edit -> Preferences -> BetterBibTex` and set citation key format to `[auth][year]`.
+Go into `Edit -> Preferences -> Sync` entering your username and password, or else create a new account if you have not already done so.
+Also check 'On item change' at the bottom left.
+Now switch to the 'Automatic Export' sub-tab and check 'On Change'.
+Exit `Preferences` and click the green sync arrow in the to right-hand corner (if you have not previously registered a Zotero database, no change will occur).
+Install the appropriate plugin for your browser by following the link [here](https://www.zotero.org/download/)
+Find a paper online, sigining in to the journal as necessary and downloading the PDF manually.
+Now return to the paper on the journal's website and test the browser plugin for Zotero which should be displayed in the top right of the screen.
+Create the bib and bst directories, and move the .bst bibliography style files into the appropriate folder by running the following:
+
+```
+mkdir -p ~/texmf/bibtex/bib
+cp ~/.config/latex/bst ~/texmf/bibtex
+```
+
+Right-click the main library folder in the left-most column, and select `Export Library`.
+Under the `Format` dropdown menu, select `Better BibTex`, selecting the `Keep Updated` box. 
+Save the file as `Zotero.bib` to ~/texmf/bibtex/bib which you previously created.
+You are now ready to cite files in your Zotero database.
+
+## [Nerd Fonts](https://github.com/ryanoasis/nerd-fonts)
+
+In order for NeoVim to load icons, it will be imporant to install a NerdFont.
+For simplicity, I have included RobotoMono in `~/.config/fonts` which you can now move to the appropriate folder on your computer by entering the following in the terminal:
+
+```
+sudo cp ~/.config/fonts/RobotoMono/ /usr/share/fonts
+```
+
+If you intend to use the stock terminal, you will need to go into the terminal's settings to change the font to RobotoMono regular.
+You are now ready to write LaTex in NeoVim inside the stock terminal.
+If you intend to upgrade your terminal to Alacritty with Tmux and the Fish shell, then proceed as follows:
+
+## [Alacritty](https://github.com/alacritty/alacritty), [Tmux](https://github.com/tmux/tmux/wiki), and [Fish](https://fishshell.com/)
+
+Run the following in the terminal:
+
+```
+sudo pacman -S alacritty
+sudo pacman -S tmux
+sudo pacman -S fish
+```
+
+You will also need to move the Tmux configuration file to the appropriate location by running:
+
+```
+sudo cp ~/.config/tmux/.tmux.conf ~/
+```
+
+Assuming that you installed Fish above, you will now need to locate fish on your operating system by running the following:
+
+```
+which fish
+```
+
+The command should return `/usr/bin/fish`.
+If the path is different, copy the path and run the following:
+
+```
+nvim ~/.config/alacritty/alacritty.yml
+```
+
+Replace '/usr/bin/fish' with the location of fish if different, saving and exiting with `Space-q`.
+Quite the terminal and open Alacritty, running the following to set a reasonable theme for Fish:
+
+```
+curl -L https://get.oh-my.fish | fish
+omf install sashimi
+```
+
+To delete the welcome message, run:
+
+```
+set fish_greeting
+```
+
+In order to reset Tmux, run:
+
+```
+Tmux kill-server
+```
+
+When you reopen Alacritty, Fish should be the default shell inside a Tmux window.
+If you want to turn on the Vim keybindings within Fish, run the following:
+
+```
+fish_vi_key_bindings
+```
+
+You are now read use NeoVim in Alacritty, complete with Tmux and the Fish shell.
+I highly recommend swapping the CapsLock and Esc keys as detailed below for using Arch on a Macbook Pro.
+
 
 ## Remapping Keys
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ I have also provided a [Cheat Sheet](https://github.com/benbrastmckie/.config/bl
 
 1. [Mac OS Installation](#Mac-OS-Installation)
 2. [Arch Linux Installation](#Arch-Linux-Installation)
+3. [Ubuntu Linux Insallation](#Ubuntu-Linux-Installation)
 
 The programs covered include: NeoVim, Git, Skim/Zathura, Zotero, Alacritty, Tmux, and Fish.
 I will also include information for globally remapping keys to better suit writing LaTeX documents with NeoVim.
@@ -613,7 +614,8 @@ fish_vi_key_bindings
 
 You are now read use NeoVim in Alacritty, complete with Tmux and the Fish shell.
 I highly recommend swapping the CapsLock and Esc keys as detailed below for using Arch on a Macbook Pro.
-# Arch Linux Installation
+
+# Ubuntu Linux Installation
 
 Open the terminal and run the following commands:
 

--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ If Git is not installed, run:
 sudo apt install git
 ```
 
-Next, install LazyGit using Yay by running:
+Next, install LazyGit using Launchpad by running:
 
 ```
 sudo add-apt-repository ppa:lazygit-team/release

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ I highly recommend swapping the CapsLock and Esc keys as detailed below for usin
 Open the terminal and run the following commands:
 
 ```
-sudo pacman -S neovim
+sudo apt install neovim
 ```
 
 Check to confirm that Python is installed:
@@ -632,7 +632,7 @@ python3 --version
 If Python is not installed, run:
 
 ```
-sudo pacman -S python
+sudo apt install python
 ```
 
 To check the health of your NeoVim install, open NeoVim by running `nvim` in the terminal and enter the following command:
@@ -658,10 +658,10 @@ sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.
 Install the FZF fuzzy finder, Ripgrep, and Pandoc with the following commands respectively:
 
 ```
-sudo pacman -S fzf
-sudo pacman -S ripgrep
-sudo pacman -S pandoc
-sudo pacman -S pandoc-citeproc
+sudo apt install fzf
+sudo apt install ripgrep
+sudo apt install pandoc
+sudo apt install pandoc-citeproc
 ```
 
 ## [Git](https://git-scm.com/)
@@ -675,34 +675,25 @@ git --version
 If Git is not installed, run:
 
 ```
-sudo pacman -S install git
-```
-
-If you don't have Yay, you can install it by running the following:
-
-```
-git clone https://aur.archlinux.org/yay.git
-cd yay
-makepkg -si
-```
-
-If you run into errors, you may be missing the following dependency, which you can add by running:
-
-```
-sudo pacman -S base-devel
+sudo apt install git
 ```
 
 Next, install LazyGit using Yay by running:
 
 ```
-yay -S lazygit
+sudo add-apt-repository ppa:lazygit-team/release
+sudo apt-get update
+sudo apt-get install lazygit
 ```
 
 ### Installing the GitHub Cli
 
 Assuming that you are using GitHub to host your repositories, it is convenient to install the GitHub Cli which allows you to make changes to your repositories directly from the terminal inside NeoVim:
 ```
-sudo pacman -S github-cli
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+sudo apt-add-repository https://cli.github.com/packages
+sudo apt update
+sudo apt install gh
 ```
 You will then need to follow the [instructions](https://cli.github.com/manual/) in order to authenticate GitHub Cli by running:
 ```
@@ -735,7 +726,7 @@ ssh-add ~/.ssh/id_rsa
 If you do not have `xclip` you can install it by running:
 
 ```
-sudo pacman -S xclip
+sudo apt install xclip
 ```
 
 After the install, run the following to copy the SSH key to your system clipboard:
@@ -757,7 +748,7 @@ cd ~/.config
 git clone https://github.com/benbrastmckie/.config.git
 mkdir -p ~/.vim/files/info
 sudo pip3 install neovim-remote
-sudo pacman -S yarn
+sudo apt install yarn
 ```
 
 If you have not already installed MacTex on your computer, you can run the following command in order to check to see if it is already installed:
@@ -769,7 +760,7 @@ latexmk --version
 To install LaTeX, run the following
 
 ```
-sudo pacman -S texlive-most
+sudo apt install texlive-full
 ```
 
 Run NeoVim to install plugins:
@@ -785,7 +776,7 @@ After the plugins finish installing, quite NeoVim with `:qa!`.
 Install the Zathura pdf viewer by running:
 
 ```
-sudo pacman -S zathura
+sudo apt install zathura
 ```
 
 After reopening NeoVim, enter the following command:
@@ -849,9 +840,9 @@ If you intend to upgrade your terminal to Alacritty with Tmux and the Fish shell
 Run the following in the terminal:
 
 ```
-sudo pacman -S alacritty
-sudo pacman -S tmux
-sudo pacman -S fish
+sudo apt install alacritty
+sudo apt install tmux
+sudo apt install fish
 ```
 
 You will also need to move the Tmux configuration file to the appropriate location by running:

--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ latexmk --version
 To install LaTeX, run the following
 
 ```
-sudo apt install texlive-most
+sudo apt install texlive-full
 ```
 
 Run NeoVim to install plugins:


### PR DESCRIPTION
I've added the Ubuntu installation instructions based on the Arch installation instructions. I've only tested what I've run on my own machine, so some of the "if this doesn't work, try this" haven't been tested, but they should run in Ubuntu. This is mostly just replacing:

```
pacman -S
```
with 

```
apt install
```
though there are a couple of packages for which the difference in installation is a bit more