### PR TITLE
Fix cmp-vimtex's information not being shown.

### DIFF
--- a/nvim/lua/user/cmp.lua
+++ b/nvim/lua/user/cmp.lua
@@ -104,6 +104,7 @@ cmp.setup {
         latex_symbols = "[Symbols]",
         cmdline = "[CMD]",
         path = "[Path]",
+        vimtex = (vim_item.menu ~= nil and vim_item.menu or ""),
       })[entry.source.name]
       return vim_item
     end,
@@ -111,8 +112,8 @@ cmp.setup {
   sources = cmp.config.sources({
     { name = "nvim_lsp" },
     { name = "luasnip" },
-    { name = "omni" },
-    -- { name = "vimtex" }, -- doesn't provide as much info as omni yet
+    -- { name = "omni" },
+    { name = "vimtex" }, -- doesn't provide as much info as omni yet
     { name = "buffer", keyword_length = 3 },
     { name = "spell",
       keyword_length = 4,


### PR DESCRIPTION
I had noticed that you tried to add `cmp-vimtex` to your sources, but that it didn't show more information than `omni`. This is a problem with the formatting function overwriting the info already stored in the `vim_item.menu` variable, when adding the kind.

It's the same problem which affected `lspkind.nvim`; I've opened a [pull request](https://github.com/onsails/lspkind.nvim/pull/72), which has now been merged.