### PR TITLE
Extra steps needed for fish setup on MacOS install

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ Whatever you do, I recommend finding something comfortable before you begin usin
 To install the Fish shell, run:
 
 ```
+brew install zoxide # prerequsite for config.fish
 brew install fish
 curl https://raw.githubusercontent.com/oh-my-fish/oh-my-fish/master/bin/install | fish
 omf install sashimi
 cp ~/.config/config-files/config.fish ~/.config/fish/config.fish
+/opt/homebrew/bin/brew shellenv >> ~/.config/fish/config.fish # Ensures that brew paths are recognised inside fish
 ```
 
 To delete the welcome message, run:
@@ -193,7 +195,7 @@ brew install pandoc
 brew install pandoc-plot
 brew install npm
 brew install wget
-sudo pip3 install neovim-remote
+brew install neovim-remote
 ```
 
 ## [NeoVim](https://neovim.io/)
@@ -1601,3 +1603,4 @@ setxkbmap
 ```
 
 Once you achieve the desired result, reboot and confirm that the mappings are running as desired.
+

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -3,14 +3,11 @@ if status is-interactive
 end
 
 bind --erase \ct
-# removes the mapping <C-t> which is being used to close the terminal in NeoVim
+# bind \ct true
 
-if type -q zoxide
+# There's a catch 22 here. xodide is called but won't be found unless
+# fish is aware of the paths set by brew:.
+#    /opt/brew/bin/brew shellenv >> ~/.config/fish/config.fish # Ensures that brew paths are recognised inside fish
+
 zoxide init fish --cmd cd | source
-# removes the mapping <C-t> which is being used to close the terminal in NeoVim
-end
 
-if type -q neofetch
-neofetch
-# runs neofetch if installed
-end


### PR DESCRIPTION
Hi, just working through your set up for MacOS and there are a couple of issues getting fish installed. The root seems to be that zoxide needs to be installed and is used before fish path is set to include homebrew paths.