### PR TITLE
Fix: Set pylint to output JSON to prevent decode error in null-ls

### DIFF
--- a/nvim/lua/neotex/plugins/lsp/none-ls.lua
+++ b/nvim/lua/neotex/plugins/lsp/none-ls.lua
@@ -64,7 +64,8 @@ return {
         -- diagnostics.pylint, -- instead of below
         diagnostics.pylint.with({
           extra_args = {
-            "--output-format=text",
+            -- "--output-format=text",
+            "--output-format=json", -- to get json output
             "--msg-template={line}:{column}:{category}:{msg}",
             "--score=no",
           },


### PR DESCRIPTION
This PR sets `--output-format=json` in the `pylint` diagnostic config.

Previously, when using `--output-format=text`, `null-ls` attempted to decode the plaintext output as JSON, leading to errors like:
"failed to decode json: Expected value but found invalid token at character 1"

This change ensures that `pylint` output is compatible with `null-ls`'s internal JSON parsing and prevents this error from occurring.
