### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #152)

### DIFF
--- a/.claude/commands/errors.md
+++ b/.claude/commands/errors.md
@@ -1,7 +1,7 @@
 ---
 description: Analyze errors and create fix plans
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, Agent
-argument-hint: [--fix TASK_NUMBER]
+argument-hint: "[--fix TASK_NUMBER]"
 model: sonnet
 ---
 

--- a/.claude/commands/fix-it.md
+++ b/.claude/commands/fix-it.md
@@ -1,7 +1,7 @@
 ---
 description: Scan files for FIX:, NOTE:, TODO:, QUESTION: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 
 # /fix-it Command

--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull/merge request for the current branch (GitHub PR or GitLab MR) (user-only)
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(glab:*), AskUserQuestion
-argument-hint: [--draft] [--assignee USER] [--label LABEL] [--reviewer USER]
+argument-hint: "[--draft] [--assignee USER] [--label LABEL] [--reviewer USER]"
 model: sonnet
 ---
 

--- a/.claude/commands/meta.md
+++ b/.claude/commands/meta.md
@@ -1,7 +1,7 @@
 ---
 description: Interactive system builder that creates TASKS for agent architecture changes (never implements directly)
 allowed-tools: Skill
-argument-hint: [PROMPT] | --analyze
+argument-hint: "[PROMPT] | --analyze"
 model: opus
 ---
 

--- a/.claude/commands/refresh.md
+++ b/.claude/commands/refresh.md
@@ -1,7 +1,7 @@
 ---
 description: Manage Claude Code resources - terminate orphaned processes and clean up files
 allowed-tools: Bash, Read, Glob, AskUserQuestion
-argument-hint: [--dry-run] [--force]
+argument-hint: "[--dry-run] [--force]"
 ---
 
 # /refresh Command

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,7 +1,7 @@
 ---
 description: Review code and create analysis reports
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [SCOPE] [--create-tasks]
+argument-hint: "[SCOPE] [--create-tasks]"
 model: sonnet
 ---
 

--- a/.claude/commands/tag.md
+++ b/.claude/commands/tag.md
@@ -1,6 +1,6 @@
 ---
 description: Create and push semantic version tags for CI/CD deployment (user-only)
-argument-hint: [--patch|--minor|--major] [--force] [--dry-run]
+argument-hint: "[--patch|--minor|--major] [--force] [--dry-run]"
 ---
 
 # Command: /tag

--- a/.claude/commands/todo.md
+++ b/.claude/commands/todo.md
@@ -1,7 +1,7 @@
 ---
 description: Archive completed and abandoned tasks
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(mv:*), Bash(mkdir:*), Bash(ls:*), Bash(find:*), Bash(jq:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [--dry-run]
+argument-hint: "[--dry-run]"
 model: sonnet
 ---
 

--- a/.claude/docs/examples/fix-it-flow-example.md
+++ b/.claude/docs/examples/fix-it-flow-example.md
@@ -71,7 +71,7 @@ Claude Code reads `.claude/commands/fix-it.md` and sees:
 ---
 description: Scan files for FIX:, NOTE:, TODO: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 ```
 

--- a/.claude/extensions/core/commands/errors.md
+++ b/.claude/extensions/core/commands/errors.md
@@ -1,7 +1,7 @@
 ---
 description: Analyze errors and create fix plans
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, Agent
-argument-hint: [--fix TASK_NUMBER]
+argument-hint: "[--fix TASK_NUMBER]"
 model: sonnet
 ---
 

--- a/.claude/extensions/core/commands/fix-it.md
+++ b/.claude/extensions/core/commands/fix-it.md
@@ -1,7 +1,7 @@
 ---
 description: Scan files for FIX:, NOTE:, TODO:, QUESTION: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 
 # /fix-it Command

--- a/.claude/extensions/core/commands/merge.md
+++ b/.claude/extensions/core/commands/merge.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull/merge request for the current branch (GitHub PR or GitLab MR) (user-only)
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(glab:*), AskUserQuestion
-argument-hint: [--draft] [--assignee USER] [--label LABEL] [--reviewer USER]
+argument-hint: "[--draft] [--assignee USER] [--label LABEL] [--reviewer USER]"
 model: sonnet
 ---
 

--- a/.claude/extensions/core/commands/meta.md
+++ b/.claude/extensions/core/commands/meta.md
@@ -1,7 +1,7 @@
 ---
 description: Interactive system builder that creates TASKS for agent architecture changes (never implements directly)
 allowed-tools: Skill
-argument-hint: [PROMPT] | --analyze
+argument-hint: "[PROMPT] | --analyze"
 model: opus
 ---
 

--- a/.claude/extensions/core/commands/refresh.md
+++ b/.claude/extensions/core/commands/refresh.md
@@ -1,7 +1,7 @@
 ---
 description: Manage Claude Code resources - terminate orphaned processes and clean up files
 allowed-tools: Bash, Read, Glob, AskUserQuestion
-argument-hint: [--dry-run] [--force]
+argument-hint: "[--dry-run] [--force]"
 ---
 
 # /refresh Command

--- a/.claude/extensions/core/commands/review.md
+++ b/.claude/extensions/core/commands/review.md
@@ -1,7 +1,7 @@
 ---
 description: Review code and create analysis reports
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [SCOPE] [--create-tasks]
+argument-hint: "[SCOPE] [--create-tasks]"
 model: sonnet
 ---
 

--- a/.claude/extensions/core/commands/tag.md
+++ b/.claude/extensions/core/commands/tag.md
@@ -1,6 +1,6 @@
 ---
 description: Create and push semantic version tags for CI/CD deployment (user-only)
-argument-hint: [--patch|--minor|--major] [--force] [--dry-run]
+argument-hint: "[--patch|--minor|--major] [--force] [--dry-run]"
 ---
 
 # Command: /tag

--- a/.claude/extensions/core/commands/todo.md
+++ b/.claude/extensions/core/commands/todo.md
@@ -1,7 +1,7 @@
 ---
 description: Archive completed and abandoned tasks
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(mv:*), Bash(mkdir:*), Bash(ls:*), Bash(find:*), Bash(jq:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [--dry-run]
+argument-hint: "[--dry-run]"
 model: sonnet
 ---
 

--- a/.claude/extensions/core/docs/examples/fix-it-flow-example.md
+++ b/.claude/extensions/core/docs/examples/fix-it-flow-example.md
@@ -71,7 +71,7 @@ Claude Code reads `.claude/commands/fix-it.md` and sees:
 ---
 description: Scan files for FIX:, NOTE:, TODO: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 ```
 

--- a/.claude/extensions/lean/commands/lake.md
+++ b/.claude/extensions/lean/commands/lake.md
@@ -1,7 +1,7 @@
 ---
 description: Run Lean build with automatic error repair
 allowed-tools: Read, Write, Edit, Bash, mcp__lean-lsp__lean_build
-argument-hint: [--clean] [--max-retries N] [--dry-run] [--module NAME]
+argument-hint: "[--clean] [--max-retries N] [--dry-run] [--module NAME]"
 ---
 
 # /lake Command

--- a/.claude/extensions/lean/commands/lean.md
+++ b/.claude/extensions/lean/commands/lean.md
@@ -1,7 +1,7 @@
 ---
 description: Manage Lean toolchain and Mathlib versions
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
-argument-hint: [check|upgrade|rollback] [--dry-run] [--version VERSION]
+argument-hint: "[check|upgrade|rollback] [--dry-run] [--version VERSION]"
 ---
 
 # /lean Command

--- a/.opencode/commands/errors.md
+++ b/.opencode/commands/errors.md
@@ -1,7 +1,7 @@
 ---
 description: Analyze errors and create fix plans
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, Task
-argument-hint: [--fix TASK_NUMBER]
+argument-hint: "[--fix TASK_NUMBER]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/commands/fix-it.md
+++ b/.opencode/commands/fix-it.md
@@ -1,7 +1,7 @@
 ---
 description: Scan files for FIX:, NOTE:, TODO:, QUESTION: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/commands/merge.md
+++ b/.opencode/commands/merge.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull/merge request for the current branch (GitHub PR or GitLab MR)
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(glab:*)
-argument-hint: [--draft] [--assignee USER] [--label LABEL] [--reviewer USER]
+argument-hint: "[--draft] [--assignee USER] [--label LABEL] [--reviewer USER]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/commands/meta.md
+++ b/.opencode/commands/meta.md
@@ -1,7 +1,7 @@
 ---
 description: Interactive system builder that creates TASKS for agent architecture changes (never implements directly)
 allowed-tools: Skill
-argument-hint: [PROMPT] | --analyze
+argument-hint: "[PROMPT] | --analyze"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/commands/refresh.md
+++ b/.opencode/commands/refresh.md
@@ -1,7 +1,7 @@
 ---
 description: Manage OpenCode resources - terminate orphaned processes and clean up files
 allowed-tools: Bash, Read, Glob, AskUserQuestion
-argument-hint: [--dry-run] [--force]
+argument-hint: "[--dry-run] [--force]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -1,7 +1,7 @@
 ---
 description: Review code and create analysis reports
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [SCOPE] [--create-tasks]
+argument-hint: "[SCOPE] [--create-tasks]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/commands/tag.md
+++ b/.opencode/commands/tag.md
@@ -1,6 +1,6 @@
 ---
 description: Create and push semantic version tags for CI/CD deployment (user-only)
-argument-hint: [--patch|--minor|--major] [--force] [--dry-run]
+argument-hint: "[--patch|--minor|--major] [--force] [--dry-run]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/commands/todo.md
+++ b/.opencode/commands/todo.md
@@ -1,7 +1,7 @@
 ---
 description: Archive completed and abandoned tasks
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(mv:*), Bash(mkdir:*), Bash(ls:*), Bash(find:*), Bash(jq:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [--dry-run]
+argument-hint: "[--dry-run]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/docs/examples/fix-it-flow-example.md
+++ b/.opencode/docs/examples/fix-it-flow-example.md
@@ -71,7 +71,7 @@ OpenCode reads `.opencode/commands/fix-it.md` and sees:
 ---
 description: Scan files for FIX:, NOTE:, TODO: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 ```
 

--- a/.opencode/extensions/core/commands/errors.md
+++ b/.opencode/extensions/core/commands/errors.md
@@ -1,7 +1,7 @@
 ---
 description: Analyze errors and create fix plans
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, Task
-argument-hint: [--fix TASK_NUMBER]
+argument-hint: "[--fix TASK_NUMBER]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/extensions/core/commands/fix-it.md
+++ b/.opencode/extensions/core/commands/fix-it.md
@@ -1,7 +1,7 @@
 ---
 description: Scan files for FIX:, NOTE:, TODO:, QUESTION: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/extensions/core/commands/merge.md
+++ b/.opencode/extensions/core/commands/merge.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull/merge request for the current branch (GitHub PR or GitLab MR)
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(glab:*)
-argument-hint: [--draft] [--assignee USER] [--label LABEL] [--reviewer USER]
+argument-hint: "[--draft] [--assignee USER] [--label LABEL] [--reviewer USER]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/extensions/core/commands/meta.md
+++ b/.opencode/extensions/core/commands/meta.md
@@ -1,7 +1,7 @@
 ---
 description: Interactive system builder that creates TASKS for agent architecture changes (never implements directly)
 allowed-tools: Skill
-argument-hint: [PROMPT] | --analyze
+argument-hint: "[PROMPT] | --analyze"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/extensions/core/commands/refresh.md
+++ b/.opencode/extensions/core/commands/refresh.md
@@ -1,7 +1,7 @@
 ---
 description: Manage OpenCode resources - terminate orphaned processes and clean up files
 allowed-tools: Bash, Read, Glob, AskUserQuestion
-argument-hint: [--dry-run] [--force]
+argument-hint: "[--dry-run] [--force]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/extensions/core/commands/review.md
+++ b/.opencode/extensions/core/commands/review.md
@@ -1,7 +1,7 @@
 ---
 description: Review code and create analysis reports
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [SCOPE] [--create-tasks]
+argument-hint: "[SCOPE] [--create-tasks]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/extensions/core/commands/tag.md
+++ b/.opencode/extensions/core/commands/tag.md
@@ -1,6 +1,6 @@
 ---
 description: Create and push semantic version tags for CI/CD deployment (user-only)
-argument-hint: [--patch|--minor|--major] [--force] [--dry-run]
+argument-hint: "[--patch|--minor|--major] [--force] [--dry-run]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/extensions/core/commands/todo.md
+++ b/.opencode/extensions/core/commands/todo.md
@@ -1,7 +1,7 @@
 ---
 description: Archive completed and abandoned tasks
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(mv:*), Bash(mkdir:*), Bash(ls:*), Bash(find:*), Bash(jq:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [--dry-run]
+argument-hint: "[--dry-run]"
 ---
 
 > **COMMAND EXECUTION MODE** — You have been invoked as this command with arguments: `$ARGUMENTS`. Execute the workflow below immediately. Do not summarize this file, ask what to do with it, or describe its contents. Start execution now.

--- a/.opencode/extensions/core/docs/examples/fix-it-flow-example.md
+++ b/.opencode/extensions/core/docs/examples/fix-it-flow-example.md
@@ -71,7 +71,7 @@ OpenCode reads `.opencode/commands/fix-it.md` and sees:
 ---
 description: Scan files for FIX:, NOTE:, TODO: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 ```
 

--- a/.opencode/extensions/lean/commands/lake.md
+++ b/.opencode/extensions/lean/commands/lake.md
@@ -1,7 +1,7 @@
 ---
 description: Run Lean build with automatic error repair
 allowed-tools: Read, Write, Edit, Bash, mcp__lean-lsp__lean_build
-argument-hint: [--clean] [--max-retries N] [--dry-run] [--module NAME]
+argument-hint: "[--clean] [--max-retries N] [--dry-run] [--module NAME]"
 ---
 
 # /lake Command

--- a/.opencode/extensions/lean/commands/lean.md
+++ b/.opencode/extensions/lean/commands/lean.md
@@ -1,7 +1,7 @@
 ---
 description: Manage Lean toolchain and Mathlib versions
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
-argument-hint: [check|upgrade|rollback] [--dry-run] [--version VERSION]
+argument-hint: "[check|upgrade|rollback] [--dry-run] [--version VERSION]"
 ---
 
 # /lean Command

--- a/specs/archive/521_add_model_opus_opencode_commands/reports/01_command-frontmatter-audit.md
+++ b/specs/archive/521_add_model_opus_opencode_commands/reports/01_command-frontmatter-audit.md
@@ -86,7 +86,7 @@ argument-hint: TASK_NUMBERS [--team [--team-size N]] [--force] [--fast|--hard] [
 ---
 description: Review code and create analysis reports
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [SCOPE] [--create-tasks]
+argument-hint: "[SCOPE] [--create-tasks]"
 ---
 ```
 **Recommended**: Add `model: opus` after `description` line.
@@ -96,7 +96,7 @@ argument-hint: [SCOPE] [--create-tasks]
 ---
 description: Analyze errors and create fix plans
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate, Task
-argument-hint: [--fix TASK_NUMBER]
+argument-hint: "[--fix TASK_NUMBER]"
 ---
 ```
 **Recommended**: Add `model: opus` after `description` line.
@@ -106,7 +106,7 @@ argument-hint: [--fix TASK_NUMBER]
 ---
 description: Manage Claude Code resources - terminate orphaned processes and clean up files
 allowed-tools: Bash, Read, Glob, AskUserQuestion
-argument-hint: [--dry-run] [--force]
+argument-hint: "[--dry-run] [--force]"
 ---
 ```
 **Recommended**: Add `model: opus` after `description` line (and also fix "Claude Code" -> "OpenCode" per Task 522).
@@ -116,7 +116,7 @@ argument-hint: [--dry-run] [--force]
 ---
 description: Archive completed and abandoned tasks
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(mv:*), Bash(mkdir:*), Bash(ls:*), Bash(find:*), Bash(jq:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [--dry-run]
+argument-hint: "[--dry-run]"
 ---
 ```
 **Recommended**: Add `model: opus` after `description` line.
@@ -126,7 +126,7 @@ argument-hint: [--dry-run]
 ---
 description: System builder for .opencode/ changes
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), TaskCreate, TaskUpdate
-argument-hint: [COMPONENT] [--preview]
+argument-hint: "[COMPONENT] [--preview]"
 ---
 ```
 **Recommended**: Add `model: opus` after `description` line.
@@ -146,7 +146,7 @@ argument-hint: TASK_NUMBER [--expand]
 ---
 description: Merge pull requests with platform detection
 allowed-tools: Bash, Read, AskUserQuestion
-argument-hint: [PR_NUMBER] [--dry-run]
+argument-hint: "[PR_NUMBER] [--dry-run]"
 ---
 ```
 **Recommended**: Add `model: opus` after `description` line.
@@ -182,7 +182,7 @@ description: Create and push semantic version tags
 ---
 description: Create and manage tasks
 allowed-tools: Skill, Bash(jq:*), Bash(git:*), Read, Edit, AskUserQuestion
-argument-hint: [DESCRIPTION] [--expand] [--recover] [--sync] [--abandon]
+argument-hint: "[DESCRIPTION] [--expand] [--recover] [--sync] [--abandon]"
 ---
 ```
 **Recommended**: Add `model: opus` after `description` line.
@@ -208,7 +208,7 @@ description: Distill and maintain memory vault
 ---
 description: Scan for FIX:/NOTE:/TODO:/QUESTION: tags
 allowed-tools: Read, Grep, Glob, Bash(git:*), TaskCreate, TaskUpdate, AskUserQuestion
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 ---
 ```
 **Recommended**: Add `model: opus` after `description` line.

--- a/specs/archive/667_create_cslib_pr_command/reports/01_pr-command-research.md
+++ b/specs/archive/667_create_cslib_pr_command/reports/01_pr-command-research.md
@@ -60,7 +60,7 @@ Commands in this system use a YAML frontmatter header followed by a Markdown bod
 ---
 description: One-line description
 allowed-tools: Bash(git:*), Bash(gh:*), AskUserQuestion, Read, Write, Edit
-argument-hint: [mode] [--options]
+argument-hint: "[mode] [--options]"
 ---
 ```
 

--- a/specs/archive/702_create_literature_command/reports/01_lit-command.md
+++ b/specs/archive/702_create_literature_command/reports/01_lit-command.md
@@ -63,7 +63,7 @@ For `/literature`, Pattern B (direct execution) is correct because:
 ---
 description: Scan files for FIX:, NOTE:, TODO:, QUESTION: tags and create structured tasks interactively
 allowed-tools: Skill
-argument-hint: [PATH...]
+argument-hint: "[PATH...]"
 model: opus
 ---
 ```
@@ -247,7 +247,7 @@ Purpose: Argument parsing and dispatch.
 ---
 description: Manage specs/literature/ — scan, convert PDFs/DJVUs, and maintain index.json
 allowed-tools: Skill
-argument-hint: [--scan|--convert [FILE]|--validate|--index FILE]
+argument-hint: "[--scan|--convert [FILE]|--validate|--index FILE]"
 ---
 ```
 

--- a/specs/archive/718_create_cite_command_file/reports/01_cite-command-research.md
+++ b/specs/archive/718_create_cite_command_file/reports/01_cite-command-research.md
@@ -29,7 +29,7 @@ Researched the command file format used in this extension system to create `cite
 ---
 description: <one-line description shown in /help>
 allowed-tools: Skill
-argument-hint: [mode1|mode2|...] [ARGS]
+argument-hint: "[mode1|mode2|...] [ARGS]"
 ---
 ```
 


### PR DESCRIPTION
Closes #152.

## Summary

Purely mechanical single-character transform to 44 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string**. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` breaks YAML in one of two ways depending on the value:

- **Single bracketed token** (e.g. `[PATH...]`, `[--fix TASK_NUMBER]`) parses as a YAML flow-sequence **array** (`["PATH..."]`), so a loader validating `argument-hint` as a `str` rejects the SKILL.
- **Multiple brackets or a pipe** (e.g. `[SCOPE] [--create-tasks]`, `[PROMPT] | --analyze`, `[--dry-run] [--force]`) is not even valid YAML — it raises a hard parser/scanner error, which stricter loaders reject outright.

Claude Code tolerates both via a lenient frontmatter parser, which is why nobody caught this until Copilot CLI tightened the type check. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show and fixes both failure modes.

## Files (44)

- `.claude/commands/tag.md`
- `.claude/commands/refresh.md`
- `.claude/commands/merge.md`
- `.opencode/commands/todo.md`
- `specs/archive/521_add_model_opus_opencode_commands/reports/01_command-frontmatter-audit.md`
- `.opencode/commands/refresh.md`
- `.opencode/extensions/lean/commands/lake.md`
- `.opencode/extensions/core/commands/meta.md`
- `.claude/extensions/core/commands/errors.md`
- `.opencode/extensions/core/docs/examples/fix-it-flow-example.md`
- `.claude/commands/fix-it.md`
- `.claude/extensions/lean/commands/lean.md`
- `.claude/extensions/core/commands/review.md`
- `.opencode/commands/tag.md`
- `.opencode/extensions/core/commands/merge.md`
- `.opencode/commands/meta.md`
- `specs/archive/667_create_cslib_pr_command/reports/01_pr-command-research.md`
- `specs/archive/718_create_cite_command_file/reports/01_cite-command-research.md`
- `.opencode/extensions/core/commands/review.md`
- `.claude/commands/todo.md`
- `.opencode/extensions/core/commands/errors.md`
- `.claude/extensions/core/commands/merge.md`
- `.claude/extensions/lean/commands/lake.md`
- `specs/archive/702_create_literature_command/reports/01_lit-command.md`
- `.opencode/extensions/core/commands/refresh.md`
- `.claude/extensions/core/commands/todo.md`
- `.claude/extensions/core/commands/refresh.md`
- `.opencode/commands/fix-it.md`
- `.claude/extensions/core/commands/tag.md`
- `.claude/commands/errors.md`
- `.opencode/commands/errors.md`
- `.opencode/extensions/core/commands/todo.md`
- `.opencode/extensions/lean/commands/lean.md`
- `.claude/extensions/core/commands/fix-it.md`
- `.opencode/docs/examples/fix-it-flow-example.md`
- `.claude/commands/review.md`
- `.claude/extensions/core/docs/examples/fix-it-flow-example.md`
- `.opencode/extensions/core/commands/fix-it.md`
- `.claude/extensions/core/commands/meta.md`
- `.claude/docs/examples/fix-it-flow-example.md`
- `.claude/commands/meta.md`
- `.opencode/commands/review.md`
- `.opencode/extensions/core/commands/tag.md`
- `.opencode/commands/merge.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- Confirmed the bare forms fail: single-bracket values load as a `list`, multi-bracket/pipe values raise a `ParserError`/`ScannerError`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
